### PR TITLE
fix: A future version of React will block javascript: URLs as a secur…

### DIFF
--- a/src/Design.js
+++ b/src/Design.js
@@ -276,13 +276,12 @@ export default class Design extends PureComponent {
             type="warning"
           >
             {cacheRestoreMessage}
-            <a
+            <span
               className={`${prefix}-design__restore-cache-alert-use`}
               onClick={this.restoreCache}
-              href="javascript:void(0);"
             >
               使用
-            </a>
+            </span>
           </Alert>
         )}
         {this.renderPreview(preview)}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -16,6 +16,8 @@
 
     &-use {
       text-decoration: none;
+      cursor: pointer;
+      color: #1890ff;
     }
   }
 


### PR DESCRIPTION
```
Warning: A future version of React will block javascript: URLs as a security precaution. Use event handlers instead if you can. If you need to generate unsafe HTML try using dangerouslySetInnerHTML instead. React was passed "javascript:void(0);".
```